### PR TITLE
Linear/MT25/ResetPassword

### DIFF
--- a/app/(pages)/(auth)/reset-password/api-reset-password/index.tsx
+++ b/app/(pages)/(auth)/reset-password/api-reset-password/index.tsx
@@ -1,0 +1,19 @@
+import { ApiAxiosInterceptor } from "@/app/react-query/axios";
+import { IResetPassword } from "../types";
+import { CustomError } from "@/app/utils/CustomError";
+
+export const ResetPasswordFn = async (data: IResetPassword) => {
+  try {
+    const response = await ApiAxiosInterceptor.post(
+      "/api/users/resetPassword",
+      data
+    );
+    if (response.status >= 200 && response.status < 300) {
+      return response.data;
+    } else {
+      throw new CustomError(response);
+    }
+  } catch (error) {
+    throw error;
+  }
+};

--- a/app/(pages)/(auth)/reset-password/page.tsx
+++ b/app/(pages)/(auth)/reset-password/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Form, Formik } from "formik";
+import * as Yup from "yup";
+import { useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
+import Spinner from "@/app/components/globals/Spinner";
+import { useMutation } from "@tanstack/react-query";
+import { ResetPasswordFn } from "./api-reset-password";
+import { IResetPassword } from "./types";
+import { toast } from "react-toastify";
+import { CustomError } from "@/app/utils/CustomError";
+
+const validationSchema = Yup.object({
+  newPassword: Yup.string()
+    .min(6, "Must be 6 characters or more")
+    .required("Password is required"),
+  confirmPassword: Yup.string()
+    .oneOf([Yup.ref("newPassword")], "Password must match")
+    .required("Confirm Password is required"),
+});
+interface FormValues {
+  token: string;
+  email: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+export default function Page() {
+  const [isParamsPresent, setIsParamsPresent] = useState(false);
+  const params = useSearchParams();
+  const email = params.get("email");
+  const token = params.get("token");
+  const router = useRouter();
+  const { mutateAsync } = useMutation({
+    mutationFn: ResetPasswordFn,
+    mutationKey: ["resetPassword"],
+  });
+  const handleParams = () => {
+    if (params.size === 0) {
+      router.push("/");
+    } else {
+      setIsParamsPresent(!isParamsPresent);
+    }
+  };
+  const initialValues: FormValues = {
+    token: token as string,
+    email: email as string,
+    newPassword: "",
+    confirmPassword: "",
+  };
+  const handleSubmit = async (values: IResetPassword) => {
+    try {
+      const res = await mutateAsync(values);
+      toast(res.message);
+      router.push("/signin");
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        const customError = error as CustomError;
+        toast(customError.response.data.message);
+        router.push("/signin");
+      }
+    }
+  };
+  useEffect(() => {
+    handleParams();
+  }, []);
+  return (
+    <main className=" container mx-auto py-16 px-2 grid">
+      {!isParamsPresent ? (
+        <div className="flex items-center justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        <>
+          <div className=" flex flex-col gap-3 text-center pb-12">
+            <h1 className=" text-4xl font-semibold">Reset password</h1>
+            <p className=" text-sm text-[#666]">
+              Enter your new password below
+            </p>
+          </div>
+          <div className="w-full max-w-[350px] mx-auto">
+            <Formik
+              initialValues={initialValues}
+              validationSchema={validationSchema}
+              onSubmit={handleSubmit}
+              className="flex flex-col gap-9 w-full"
+            >
+              {(formik) => (
+                <Form className="grid gap-3 w-full">
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="newPassword">
+                      {formik.touched.newPassword &&
+                      formik.errors.newPassword ? (
+                        <p className=" text-red-600">
+                          {formik.errors.newPassword}
+                        </p>
+                      ) : (
+                        "New password"
+                      )}
+                    </label>
+                    <input
+                      id="newPassword"
+                      name="newPassword"
+                      type="password"
+                      autoComplete="true"
+                      onChange={formik.handleChange}
+                      value={formik.values.newPassword}
+                      className="bg-[#F0EDE8] py-3  px-2 rounded-lg focus:outline-[#33A077]"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="confirmPassword">
+                      {formik.touched.confirmPassword &&
+                      formik.errors.confirmPassword ? (
+                        <p className=" text-red-600">
+                          {formik.errors.confirmPassword}
+                        </p>
+                      ) : (
+                        "Confirm Password"
+                      )}
+                    </label>
+                    <input
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      type="password"
+                      autoComplete="true"
+                      onChange={formik.handleChange}
+                      value={formik.values.confirmPassword}
+                      className="bg-[#F0EDE8] py-3  px-2 rounded-lg focus:outline-[#33A077]"
+                    />
+                  </div>
+                  <button
+                    type="submit"
+                    className=" bg-[#33A077] hover:bg-[#227356] py-3  px-1 text-white rounded-lg mt-4 w-full"
+                  >
+                    Change Password
+                  </button>
+                </Form>
+              )}
+            </Formik>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}

--- a/app/(pages)/(auth)/reset-password/types/index.tsx
+++ b/app/(pages)/(auth)/reset-password/types/index.tsx
@@ -1,0 +1,5 @@
+export type IResetPassword = {
+  email: string;
+  token: string;
+  newPassword: string;
+};

--- a/app/(pages)/(auth)/signin/components/ForgotPasswordModal.tsx
+++ b/app/(pages)/(auth)/signin/components/ForgotPasswordModal.tsx
@@ -63,8 +63,8 @@ const ForgotPassModalOpen: React.FC<Props> = ({ closeModal }) => {
                   alt="close"
                   width={25}
                   height={10}
-                  style={{ width: "25px", height: "10px" }}
-                  className=" absolute top-7 right-5 bg-white rounded-full"
+                  style={{ width: "25px", height: "20px" }}
+                  className=" absolute top-8 right-5 bg-white rounded-full"
                 />
               </button>
 

--- a/app/(pages)/(auth)/signin/components/Form.tsx
+++ b/app/(pages)/(auth)/signin/components/Form.tsx
@@ -9,6 +9,7 @@ import { signInUser } from "../api-signin";
 import { ISignIn } from "../types";
 import { useRouter } from "next/navigation";
 import ForgotPassModalOpen from "./ForgotPasswordModal";
+import Spinner from "@/app/components/globals/Spinner";
 
 const validationSchema = Yup.object({
   email: Yup.string()
@@ -114,7 +115,7 @@ export default function SignUpForm() {
               type="submit"
               className=" bg-[#33A077] hover:bg-[#227356] py-3  px-1 text-white rounded-lg mt-4 w-full"
             >
-              Sign in
+              {formik.isSubmitting ? <Spinner /> : "Sign in"}
             </button>
           </Form>
         )}

--- a/app/(pages)/(auth)/signup/components/Form.tsx
+++ b/app/(pages)/(auth)/signup/components/Form.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Form, Formik } from "formik";
 import * as Yup from "yup";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { signUpUser } from "../api-signup";
 import { ISignUp } from "../types";
 import { toast } from "react-toastify";
@@ -10,6 +10,7 @@ import { useRouter } from "next/navigation";
 import { countryList } from "@/app/utils/ListOfCountries";
 import Select from "react-select";
 import { useEffect, useState } from "react";
+import Spinner from "@/app/components/globals/Spinner";
 
 const validationSchema = Yup.object({
   name: Yup.string()
@@ -204,7 +205,7 @@ export default function SignUpForm() {
             type="submit"
             className=" bg-[#33A077] hover:bg-[#227356] py-3  px-1 text-white rounded-lg mt-4 w-full"
           >
-            Sign up
+            {formik.isSubmitting ? <Spinner /> : "Sign up"}
           </button>
         </Form>
       )}

--- a/app/components/globals/Footer.tsx
+++ b/app/components/globals/Footer.tsx
@@ -10,7 +10,10 @@ const overlock = Overlock({
 
 export default function Footer() {
   const pathname = usePathname();
-  const auth = pathname === "/signup" || pathname === "/signin";
+  const auth =
+    pathname === "/signup" ||
+    pathname === "/signin" ||
+    pathname === "/reset-password";
   if (auth) {
     return null;
   }

--- a/app/components/globals/NavbarDesktop.tsx
+++ b/app/components/globals/NavbarDesktop.tsx
@@ -11,7 +11,10 @@ const overlock = Overlock({
 
 export default function NavbarDesktop() {
   const pathname = usePathname();
-  const auth = pathname === "/signup" || pathname === "/signin";
+  const auth =
+    pathname === "/signup" ||
+    pathname === "/signin" ||
+    pathname === "/reset-password";
   if (auth) {
     return (
       <nav className="hidden md:flex items-center justify-between container mx-auto pt-4 pb-8">

--- a/app/components/globals/NavbarMobile.tsx
+++ b/app/components/globals/NavbarMobile.tsx
@@ -15,7 +15,10 @@ export default function NavbarMobile() {
     setIsNavOpen(!isNavOpen);
   };
   const pathname = usePathname();
-  const auth = pathname === "/signup" || pathname === "/signin";
+  const auth =
+    pathname === "/signup" ||
+    pathname === "/signin" ||
+    pathname === "/reset-password";
   if (auth) {
     return (
       <nav className="relative md:hidden flex items-center justify-between container mx-auto py-4 px-2">

--- a/app/components/home/Hero.tsx
+++ b/app/components/home/Hero.tsx
@@ -8,7 +8,7 @@ export default function Hero() {
     justify-between gap-4 px-2"
     >
       <div className=" relative z-10 justify-center gap-3">
-        <h1 className="text-center text-[#33A077] text-6xl lg:text-6xl font-bold pb-3">
+        <h1 className="text-center text-[#33A077] text-4xl md:text-6xl lg:text-6xl font-bold pb-3">
           Do not throw it, sell it!
         </h1>
         <div className="w-full pb-6">


### PR DESCRIPTION
- Added a loading spinner for all auth routes
- User can now reset their password
- If no params are present in the url (forced routing), the user will be redirected to the homepage
- If params are present, the user will be asked to provide a new password and confirm it by typing it again
- If the token is invalid, the user will get a toast showing the failure message and then gets redirected to sign in page (where they can reset the password again or sign in)
- If the password is successfully reseted, the user will get a toast that show the success message and then gets redirected to the sign in page